### PR TITLE
encode(0) returns "0"

### DIFF
--- a/base36.go
+++ b/base36.go
@@ -35,11 +35,15 @@ var (
 func Encode(value uint64) string {
 	var res [16]byte
 	var i int
-	for i = len(res) - 1; value != 0; i-- {
+	for i = len(res) - 1; ; i-- {
 		res[i] = base36[value%36]
 		value /= 36
+		if value == 0 {
+			break
+		}
 	}
-	return string(res[i+1:])
+
+	return string(res[i:])
 }
 
 // Decode decodes a base36-encoded string.

--- a/base36_test.go
+++ b/base36_test.go
@@ -12,7 +12,7 @@ var raw = []uint64{0, 50, 100, 999, 1000, 1111, 5959, 99999,
 	123456789, 5481594952936519619, math.MaxInt64 / 2048, math.MaxInt64 / 512,
 	math.MaxInt64, math.MaxUint64}
 
-var encoded = []string{"", "1E", "2S", "RR", "RS", "UV", "4LJ", "255R",
+var encoded = []string{"0", "1E", "2S", "RR", "RS", "UV", "4LJ", "255R",
 	"21I3V9", "15N9Z8L3AU4EB", "18CE53UN18F", "4XDKKFEK4XR",
 	"1Y2P0IJ32E8E7", "3W5E11264SGSF"}
 

--- a/example_test.go
+++ b/example_test.go
@@ -3,9 +3,7 @@ package base36_test
 import (
 	"fmt"
 
-	// change depending on which github account the package belongs to 
-	//"github.com/martinlindhe/base36"
-	"github.com/buzzfrog/base36"
+	"github.com/martinlindhe/base36"
 
 )
 

--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,10 @@ package base36_test
 import (
 	"fmt"
 
-	"github.com/martinlindhe/base36"
+	// change depending on which github account the package belongs to 
+	//"github.com/martinlindhe/base36"
+	"github.com/buzzfrog/base36"
+
 )
 
 func ExampleEncode() {


### PR DESCRIPTION
Fix for #4
Comment: I don't like the "hard coded" value in example_test.go that bounds the repo to a specific user. Maybe this could be fixed if modules is used instead?

So, You have to to switch the comments so it points to your version of base36:
```
// change depending on which github account the package belongs to 
//"github.com/martinlindhe/base36"
"github.com/buzzfrog/base36"
```